### PR TITLE
IBX-829: [CI] Switched default branch name to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - '[0-9]+.[0-9]+'
   pull_request: ~
 


### PR DESCRIPTION
Synced ezsystems/ezplatform-standard-design to ibexa/standard-design

Triggered by https://github.com/ezsystems/ezplatform-standard-design/pull/14 , but I had to make other CI changes when merging upstream:
1) Adapt Travis setup to 3.3 version of Ibexa DXP
2) Remove unsupported PHP versions from Github Actions matrix
3) Renamed master branch to main

Also there are some licensing changes (@alongosz ) and changes in composer.json that are present in master - looks like this repo has not been synced in a long time.