### PR TITLE
IBX-1589: Renamed Extension ez_platform_standard_design to ibexa_standard_design

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('ez_platform_standard_design');
+        $treeBuilder = new TreeBuilder(IbexaStandardDesignExtension::EXTENSION_NAME);
 
         $rootNode = $treeBuilder->getRootNode();
         $rootNode

--- a/src/bundle/DependencyInjection/IbexaStandardDesignExtension.php
+++ b/src/bundle/DependencyInjection/IbexaStandardDesignExtension.php
@@ -16,7 +16,14 @@ use Symfony\Component\Yaml\Yaml;
 
 class IbexaStandardDesignExtension extends Extension implements PrependExtensionInterface
 {
-    const OVERRIDE_KERNEL_TEMPLATES_PARAM_NAME = 'ez_platform_standard_design.override_kernel_templates';
+    public const EXTENSION_NAME = 'ibexa_standard_design';
+
+    public const OVERRIDE_KERNEL_TEMPLATES_PARAM_NAME = 'ez_platform_standard_design.override_kernel_templates';
+
+    public function getAlias(): string
+    {
+        return self::EXTENSION_NAME;
+    }
 
     /**
      * Load Bundle Configuration.


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#5

- [x] bff5ac1 IBX-1589: Renamed Extension ez_platform_standard_design to ibexa_standard_design

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // full stack Behat coverage
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review
