### PR TITLE
IBX-1829: Fixed incorrect bundle name used for mapping core views paths

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/KernelOverridePass.php
+++ b/src/bundle/DependencyInjection/Compiler/KernelOverridePass.php
@@ -54,7 +54,8 @@ class KernelOverridePass implements CompilerPassInterface
         }
 
         $bundlesMetaData = $container->getParameter('kernel.bundles_metadata');
-        if (!isset($bundlesMetaData['EzPublishCoreBundle']['path'])) {
+        $path = $bundlesMetaData['IbexaCoreBundle']['path'] ?? null;
+        if (null === $path) {
             return;
         }
 
@@ -62,7 +63,7 @@ class KernelOverridePass implements CompilerPassInterface
             ? $container->getParameter('ezdesign.templates_path_map')
             : [];
 
-        $templatesPathMap['standard'][] = $bundlesMetaData['EzPublishCoreBundle']['path'] . '/Resources/views';
+        $templatesPathMap['standard'][] = $path . '/Resources/views';
 
         $container->setParameter('ezdesign.templates_path_map', $templatesPathMap);
     }

--- a/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
@@ -51,7 +51,7 @@ class KernelOverridePassTest extends AbstractCompilerPassTestCase
         $this->setParameter(
             'kernel.bundles_metadata',
             [
-                'EzPublishCoreBundle' => [
+                'IbexaCoreBundle' => [
                     'path' => '/some/path',
                 ],
             ]


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1829](https://issues.ibexa.co/browse/IBX-1829)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

We've missed changing `EzPublishCoreBundle` array key needed to find core bundle paths. Updated to `IbexaCoreBundle` so 
`ibexa/core/src/bundle/Core/Resources/views` is mapped as a fallback standard design theme directory (behavior taken from 3.3).

TBH I think we should redefine those templates properly in `bundle/Resources/templates/themes/standard`, but not doing this due to expected BC.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Updated automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review