### PR TITLE
IBX-1696: Rebranded Container parameters and Config Resolver namespaces

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/KernelOverridePass.php
+++ b/src/bundle/DependencyInjection/Compiler/KernelOverridePass.php
@@ -59,13 +59,13 @@ class KernelOverridePass implements CompilerPassInterface
             return;
         }
 
-        $templatesPathMap = $container->hasParameter('ezdesign.templates_path_map')
-            ? $container->getParameter('ezdesign.templates_path_map')
+        $templatesPathMap = $container->hasParameter('ibexa.design.templates.path_map')
+            ? $container->getParameter('ibexa.design.templates.path_map')
             : [];
 
         $templatesPathMap['standard'][] = $path . '/Resources/views';
 
-        $container->setParameter('ezdesign.templates_path_map', $templatesPathMap);
+        $container->setParameter('ibexa.design.templates.path_map', $templatesPathMap);
     }
 }
 

--- a/src/bundle/DependencyInjection/Compiler/StandardThemePass.php
+++ b/src/bundle/DependencyInjection/Compiler/StandardThemePass.php
@@ -26,17 +26,17 @@ class StandardThemePass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasParameter('ezdesign.design_list')) {
+        if (!$container->hasParameter('ibexa.design.list')) {
             return;
         }
 
-        $designList = $container->getParameter('ezdesign.design_list');
+        $designList = $container->getParameter('ibexa.design.list');
         foreach ($designList as $designName => $themes) {
             if (!in_array('standard', $themes)) {
                 $designList[$designName][] = 'standard';
             }
         }
-        $container->setParameter('ezdesign.design_list', $designList);
+        $container->setParameter('ibexa.design.list', $designList);
     }
 }
 

--- a/src/bundle/DependencyInjection/IbexaStandardDesignExtension.php
+++ b/src/bundle/DependencyInjection/IbexaStandardDesignExtension.php
@@ -18,7 +18,7 @@ class IbexaStandardDesignExtension extends Extension implements PrependExtension
 {
     public const EXTENSION_NAME = 'ibexa_standard_design';
 
-    public const OVERRIDE_KERNEL_TEMPLATES_PARAM_NAME = 'ez_platform_standard_design.override_kernel_templates';
+    public const OVERRIDE_KERNEL_TEMPLATES_PARAM_NAME = 'ibexa.design.standard.override_kernel_templates';
 
     public function getAlias(): string
     {

--- a/src/bundle/Resources/config/override/ezpublish.yaml
+++ b/src/bundle/Resources/config/override/ezpublish.yaml
@@ -1,13 +1,13 @@
 parameters:
-    ezpublish.content_view.viewbase_layout: '@@ibexadesign/viewbase_layout.html.twig'
+    ibexa.content_view.viewbase_layout: '@@ibexadesign/viewbase_layout.html.twig'
 
-    ezplatform.default_view_templates.content.full: '@@ibexadesign/default/content/full.html.twig'
-    ezplatform.default_view_templates.content.line: '@@ibexadesign/default/content/line.html.twig'
-    ezplatform.default_view_templates.content.text_linked: '@@ibexadesign/default/content/text_linked.html.twig'
-    ezplatform.default_view_templates.content.embed: '@@ibexadesign/default/content/embed.html.twig'
-    ezplatform.default_view_templates.content.embed_image: '@@ibexadesign/default/content/embed_image.html.twig'
-    ezplatform.default_view_templates.block: '@@ibexadesign/default/block/block.html.twig'
+    ibexa.default_view_templates.content.full: '@@ibexadesign/default/content/full.html.twig'
+    ibexa.default_view_templates.content.line: '@@ibexadesign/default/content/line.html.twig'
+    ibexa.default_view_templates.content.text_linked: '@@ibexadesign/default/content/text_linked.html.twig'
+    ibexa.default_view_templates.content.embed: '@@ibexadesign/default/content/embed.html.twig'
+    ibexa.default_view_templates.content.embed_image: '@@ibexadesign/default/content/embed_image.html.twig'
+    ibexa.default_view_templates.block: '@@ibexadesign/default/block/block.html.twig'
 
-    ezplatform.default_templates.pagelayout: '@@ibexadesign/pagelayout.html.twig'
-    ezplatform.default_templates.field_templates: '@@ibexadesign/content_fields.html.twig'
-    ezplatform.default_templates.fielddefinition_settings_templates: '@@ibexadesign/fielddefinition_settings.html.twig'
+    ibexa.default_templates.pagelayout: '@@ibexadesign/pagelayout.html.twig'
+    ibexa.default_templates.field_templates: '@@ibexadesign/content_fields.html.twig'
+    ibexa.default_templates.fielddefinition_settings_templates: '@@ibexadesign/fielddefinition_settings.html.twig'

--- a/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
@@ -35,7 +35,7 @@ class KernelOverridePassTest extends AbstractCompilerPassTestCase
      */
     protected function registerCompilerPass(ContainerBuilder $container): void
     {
-        $container->setParameter('ez_platform_standard_design.override_kernel_templates', true);
+        $container->setParameter('ibexa.design.standard.override_kernel_templates', true);
 
         $container->addCompilerPass(new KernelOverridePass());
     }
@@ -47,7 +47,7 @@ class KernelOverridePassTest extends AbstractCompilerPassTestCase
      */
     public function testKernelViewsDirectoryIsMappedToStandardTheme(array $templatesPathMap)
     {
-        $this->setParameter('ezdesign.templates_path_map', $templatesPathMap);
+        $this->setParameter('ibexa.design.templates.path_map', $templatesPathMap);
         $this->setParameter(
             'kernel.bundles_metadata',
             [
@@ -62,7 +62,7 @@ class KernelOverridePassTest extends AbstractCompilerPassTestCase
         $templatesPathMap['standard'][] = '/some/path/Resources/views';
 
         self::assertContainerBuilderHasParameter(
-            'ezdesign.templates_path_map',
+            'ibexa.design.templates.path_map',
             $templatesPathMap
         );
     }

--- a/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
@@ -64,11 +64,11 @@ class StandardThemePassTest extends AbstractCompilerPassTestCase
         array $designList,
         array $expectedDesignList
     ) {
-        $this->setParameter('ezdesign.design_list', $designList);
+        $this->setParameter('ibexa.design.list', $designList);
 
         $this->compile();
 
-        self::assertContainerBuilderHasParameter('ezdesign.design_list', $expectedDesignList);
+        self::assertContainerBuilderHasParameter('ibexa.design.list', $expectedDesignList);
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#31

Rebranded service container parameter names and Ibexa Config Resolver namespaces to follow unified pattern

### TODO

- [ ] Run regressions
- [ ] Test manually
