### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\EzPlatformStandardDesignBundle\\": "src/bundle",
             "Ibexa\\StandardDesign\\": "src/lib/",
             "Ibexa\\Bundle\\StandardDesign\\": "src/bundle/",
             "Ibexa\\Contracts\\StandardDesign\\": "src/contracts/"
@@ -29,7 +28,6 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "EzSystems\\Tests\\EzPlatformStandardDesignBundle\\": "tests/bundle",
             "Ibexa\\Tests\\StandardDesign\\": "tests/lib/",
             "Ibexa\\Tests\\Bundle\\StandardDesign\\": "tests/bundle/"
         }

--- a/src/bundle/DependencyInjection/Compiler/KernelOverridePass.php
+++ b/src/bundle/DependencyInjection/Compiler/KernelOverridePass.php
@@ -68,5 +68,3 @@ class KernelOverridePass implements CompilerPassInterface
         $container->setParameter('ibexa.design.templates.path_map', $templatesPathMap);
     }
 }
-
-class_alias(KernelOverridePass::class, 'EzSystems\EzPlatformStandardDesignBundle\DependencyInjection\Compiler\EzKernelOverridePass');

--- a/src/bundle/DependencyInjection/Compiler/StandardThemePass.php
+++ b/src/bundle/DependencyInjection/Compiler/StandardThemePass.php
@@ -39,5 +39,3 @@ class StandardThemePass implements CompilerPassInterface
         $container->setParameter('ibexa.design.list', $designList);
     }
 }
-
-class_alias(StandardThemePass::class, 'EzSystems\EzPlatformStandardDesignBundle\DependencyInjection\Compiler\StandardThemePass');

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -35,5 +35,3 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 }
-
-class_alias(Configuration::class, 'EzSystems\EzPlatformStandardDesignBundle\DependencyInjection\Configuration');

--- a/src/bundle/DependencyInjection/IbexaStandardDesignExtension.php
+++ b/src/bundle/DependencyInjection/IbexaStandardDesignExtension.php
@@ -70,5 +70,3 @@ class IbexaStandardDesignExtension extends Extension implements PrependExtension
         $containerBuilder->addResource(new FileResource($configFile));
     }
 }
-
-class_alias(IbexaStandardDesignExtension::class, 'EzSystems\EzPlatformStandardDesignBundle\DependencyInjection\EzPlatformStandardDesignExtension');

--- a/src/bundle/IbexaStandardDesignBundle.php
+++ b/src/bundle/IbexaStandardDesignBundle.php
@@ -28,5 +28,3 @@ class IbexaStandardDesignBundle extends Bundle
         $container->addCompilerPass(new StandardThemePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
     }
 }
-
-class_alias(IbexaStandardDesignBundle::class, 'EzSystems\EzPlatformStandardDesignBundle\EzPlatformStandardDesignBundle');

--- a/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
@@ -96,5 +96,3 @@ class KernelOverridePassTest extends AbstractCompilerPassTestCase
         }
     }
 }
-
-class_alias(KernelOverridePassTest::class, 'EzSystems\Tests\EzPlatformStandardDesignBundle\DependencyInjection\Compiler\EzKernelOverridePassTest');

--- a/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
@@ -81,5 +81,3 @@ class StandardThemePassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new StandardThemePass());
     }
 }
-
-class_alias(StandardThemePassTest::class, 'EzSystems\Tests\EzPlatformStandardDesignBundle\DependencyInjection\Compiler\StandardThemePassTest');

--- a/tests/bundle/DependencyInjection/EzPlatformStandardDesignExtensionTest.php
+++ b/tests/bundle/DependencyInjection/EzPlatformStandardDesignExtensionTest.php
@@ -34,5 +34,3 @@ class EzPlatformStandardDesignExtensionTest extends AbstractExtensionTestCase
         );
     }
 }
-
-class_alias(EzPlatformStandardDesignExtensionTest::class, 'EzSystems\Tests\EzPlatformStandardDesignBundle\DependencyInjection\EzPlatformStandardDesignExtensionTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `ez_class` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
