### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/KernelOverridePassTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class KernelOverridePassTest extends AbstractCompilerPassTestCase
 {
-    public function getTemplatesPathMap()
+    public function getTemplatesPathMap(): array
     {
         return [
             [[]],
@@ -45,7 +45,7 @@ class KernelOverridePassTest extends AbstractCompilerPassTestCase
      *
      * @param array $templatesPathMap
      */
-    public function testKernelViewsDirectoryIsMappedToStandardTheme(array $templatesPathMap)
+    public function testKernelViewsDirectoryIsMappedToStandardTheme(array $templatesPathMap): void
     {
         $this->setParameter('ibexa.design.templates.path_map', $templatesPathMap);
         $this->setParameter(
@@ -67,7 +67,7 @@ class KernelOverridePassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    public function testKernelTemplateNamesHaveEzDesignPrefix()
+    public function testKernelTemplateNamesHaveEzDesignPrefix(): void
     {
         $this->container->compile();
 

--- a/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
@@ -22,7 +22,7 @@ class StandardThemePassTest extends AbstractCompilerPassTestCase
     /**
      * Data provider returning various Ibexa Design Lists configurations.
      */
-    public function getDesignList()
+    public function getDesignList(): array
     {
         return [
             [
@@ -63,7 +63,7 @@ class StandardThemePassTest extends AbstractCompilerPassTestCase
     public function testStandardThemeIsAppendedToEveryDesign(
         array $designList,
         array $expectedDesignList
-    ) {
+    ): void {
         $this->setParameter('ibexa.design.list', $designList);
 
         $this->compile();


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
